### PR TITLE
feat: Add support for vendor-specific file managers and enhance file manager selection

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -288,6 +288,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "grantStoragePermissionDesc": MessageLookupByLibrary.simpleMessage(
       "Mounting local storage is a must, otherwise no permission to read and write files",
     ),
+    "huaweiFileManager": MessageLookupByLibrary.simpleMessage(
+      "Huawei File Manager",
+    ),
     "importantSettings": MessageLookupByLibrary.simpleMessage(
       "Important settings",
     ),
@@ -337,6 +340,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "noPermissionToOpenFile": MessageLookupByLibrary.simpleMessage(
       "No permission to open this file",
     ),
+    "noSuitableFileManagerFound": MessageLookupByLibrary.simpleMessage(
+      "No suitable file manager found",
+    ),
     "notificationClicked": m25,
     "notificationManagerInitFailed": m26,
     "notificationManagerInitialized": MessageLookupByLibrary.simpleMessage(
@@ -358,6 +364,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "openFileManagerFailed": m30,
     "openFileResult": m31,
     "openListDownloadDirectory": m32,
+    "openWithFileManager": MessageLookupByLibrary.simpleMessage(
+      "Open with File Manager",
+    ),
+    "oppoFileManager": MessageLookupByLibrary.simpleMessage(
+      "OPPO File Manager",
+    ),
     "parseFilenameFailed": m33,
     "pending": MessageLookupByLibrary.simpleMessage("Pending"),
     "preparingDownload": MessageLookupByLibrary.simpleMessage(
@@ -368,8 +380,14 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "refresh": MessageLookupByLibrary.simpleMessage("Refresh"),
     "releasePage": MessageLookupByLibrary.simpleMessage("Release Page"),
+    "samsungFileManager": MessageLookupByLibrary.simpleMessage(
+      "Samsung File Manager",
+    ),
     "selectAppToOpen": MessageLookupByLibrary.simpleMessage(
       "Select app to open",
+    ),
+    "selectFileManager": MessageLookupByLibrary.simpleMessage(
+      "Select File Manager",
     ),
     "setAdminPassword": MessageLookupByLibrary.simpleMessage(
       "Set admin password",
@@ -396,8 +414,18 @@ class MessageLookup extends MessageLookupByLibrary {
     "startDownload": m37,
     "startDownloadFile": m38,
     "startTime": MessageLookupByLibrary.simpleMessage("Start time"),
+    "systemDefault": MessageLookupByLibrary.simpleMessage("System Default"),
+    "tryAnotherFileManager": MessageLookupByLibrary.simpleMessage(
+      "Try another file manager",
+    ),
     "tryToOpenFile": m39,
     "uiSettings": MessageLookupByLibrary.simpleMessage("UI"),
+    "useDefaultFileManager": MessageLookupByLibrary.simpleMessage(
+      "Use System Default",
+    ),
+    "useVendorFileManager": MessageLookupByLibrary.simpleMessage(
+      "Use Vendor File Manager",
+    ),
     "userCancelledDownload": MessageLookupByLibrary.simpleMessage(
       "User cancelled download",
     ),
@@ -406,10 +434,16 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "viewDownloads": MessageLookupByLibrary.simpleMessage("View Downloads"),
     "viewLocation": MessageLookupByLibrary.simpleMessage("View Location"),
+    "vivoFileManager": MessageLookupByLibrary.simpleMessage(
+      "Vivo File Manager",
+    ),
     "wakeLock": MessageLookupByLibrary.simpleMessage("Wake lock"),
     "wakeLockDesc": MessageLookupByLibrary.simpleMessage(
       "Prevent CPU from sleeping when screen is off. (May cause app killed in background on some devices)",
     ),
     "webPage": MessageLookupByLibrary.simpleMessage("Web Page"),
+    "xiaomiFileManager": MessageLookupByLibrary.simpleMessage(
+      "Xiaomi File Manager",
+    ),
   };
 }

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -236,6 +236,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "grantStoragePermissionDesc": MessageLookupByLibrary.simpleMessage(
       "挂载本地存储时必须授予，否则无权限读写文件",
     ),
+    "huaweiFileManager": MessageLookupByLibrary.simpleMessage("华为文件管理"),
     "importantSettings": MessageLookupByLibrary.simpleMessage("重要"),
     "inProgress": MessageLookupByLibrary.simpleMessage("进行中"),
     "initializingNotificationManager": MessageLookupByLibrary.simpleMessage(
@@ -265,6 +266,9 @@ class MessageLookup extends MessageLookupByLibrary {
       "没有权限安装 APK 文件，请在设置中开启安装权限",
     ),
     "noPermissionToOpenFile": MessageLookupByLibrary.simpleMessage("没有权限打开此文件"),
+    "noSuitableFileManagerFound": MessageLookupByLibrary.simpleMessage(
+      "未找到合适的文件管理器",
+    ),
     "notificationClicked": m25,
     "notificationManagerInitFailed": m26,
     "notificationManagerInitialized": MessageLookupByLibrary.simpleMessage(
@@ -282,13 +286,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "openFileManagerFailed": m30,
     "openFileResult": m31,
     "openListDownloadDirectory": m32,
+    "openWithFileManager": MessageLookupByLibrary.simpleMessage("用文件管理器打开"),
+    "oppoFileManager": MessageLookupByLibrary.simpleMessage("OPPO文件管理"),
     "parseFilenameFailed": m33,
     "pending": MessageLookupByLibrary.simpleMessage("等待中"),
     "preparingDownload": MessageLookupByLibrary.simpleMessage("准备下载..."),
     "preparingDownloadStatus": MessageLookupByLibrary.simpleMessage("准备下载..."),
     "refresh": MessageLookupByLibrary.simpleMessage("刷新"),
     "releasePage": MessageLookupByLibrary.simpleMessage("发布页面"),
+    "samsungFileManager": MessageLookupByLibrary.simpleMessage("三星文件管理"),
     "selectAppToOpen": MessageLookupByLibrary.simpleMessage("选择应用打开"),
+    "selectFileManager": MessageLookupByLibrary.simpleMessage("选择文件管理器"),
     "setAdminPassword": MessageLookupByLibrary.simpleMessage("设置admin密码"),
     "setDefaultDirectory": MessageLookupByLibrary.simpleMessage("是否设为初始目录？"),
     "settings": MessageLookupByLibrary.simpleMessage("设置"),
@@ -306,18 +314,24 @@ class MessageLookup extends MessageLookupByLibrary {
     "startDownload": m37,
     "startDownloadFile": m38,
     "startTime": MessageLookupByLibrary.simpleMessage("开始时间"),
+    "systemDefault": MessageLookupByLibrary.simpleMessage("系统默认"),
+    "tryAnotherFileManager": MessageLookupByLibrary.simpleMessage("尝试其他文件管理器"),
     "tryToOpenFile": m39,
     "uiSettings": MessageLookupByLibrary.simpleMessage("界面"),
+    "useDefaultFileManager": MessageLookupByLibrary.simpleMessage("使用系统默认"),
+    "useVendorFileManager": MessageLookupByLibrary.simpleMessage("使用厂商文件管理器"),
     "userCancelledDownload": MessageLookupByLibrary.simpleMessage("用户取消下载"),
     "userCancelledDownloadError": MessageLookupByLibrary.simpleMessage(
       "用户取消下载",
     ),
     "viewDownloads": MessageLookupByLibrary.simpleMessage("查看下载"),
     "viewLocation": MessageLookupByLibrary.simpleMessage("查看位置"),
+    "vivoFileManager": MessageLookupByLibrary.simpleMessage("Vivo文件管理"),
     "wakeLock": MessageLookupByLibrary.simpleMessage("唤醒锁"),
     "wakeLockDesc": MessageLookupByLibrary.simpleMessage(
       "开启防止锁屏后CPU休眠，保持进程在后台运行。（部分系统可能导致杀后台）",
     ),
     "webPage": MessageLookupByLibrary.simpleMessage("网页"),
+    "xiaomiFileManager": MessageLookupByLibrary.simpleMessage("小米文件管理"),
   };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1249,6 +1249,121 @@ class S {
     );
   }
 
+  /// `选择文件管理器`
+  String get selectFileManager {
+    return Intl.message(
+      '选择文件管理器',
+      name: 'selectFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `系统默认`
+  String get systemDefault {
+    return Intl.message('系统默认', name: 'systemDefault', desc: '', args: []);
+  }
+
+  /// `华为文件管理`
+  String get huaweiFileManager {
+    return Intl.message(
+      '华为文件管理',
+      name: 'huaweiFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `小米文件管理`
+  String get xiaomiFileManager {
+    return Intl.message(
+      '小米文件管理',
+      name: 'xiaomiFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `OPPO文件管理`
+  String get oppoFileManager {
+    return Intl.message(
+      'OPPO文件管理',
+      name: 'oppoFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Vivo文件管理`
+  String get vivoFileManager {
+    return Intl.message(
+      'Vivo文件管理',
+      name: 'vivoFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `三星文件管理`
+  String get samsungFileManager {
+    return Intl.message(
+      '三星文件管理',
+      name: 'samsungFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `使用系统默认`
+  String get useDefaultFileManager {
+    return Intl.message(
+      '使用系统默认',
+      name: 'useDefaultFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `使用厂商文件管理器`
+  String get useVendorFileManager {
+    return Intl.message(
+      '使用厂商文件管理器',
+      name: 'useVendorFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `用文件管理器打开`
+  String get openWithFileManager {
+    return Intl.message(
+      '用文件管理器打开',
+      name: 'openWithFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `未找到合适的文件管理器`
+  String get noSuitableFileManagerFound {
+    return Intl.message(
+      '未找到合适的文件管理器',
+      name: 'noSuitableFileManagerFound',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `尝试其他文件管理器`
+  String get tryAnotherFileManager {
+    return Intl.message(
+      '尝试其他文件管理器',
+      name: 'tryAnotherFileManager',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `已打开下载目录`
   String get downloadDirectoryOpened {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -408,6 +408,18 @@
       }
     }
   },
+  "selectFileManager": "Select File Manager",
+  "systemDefault": "System Default",
+  "huaweiFileManager": "Huawei File Manager",
+  "xiaomiFileManager": "Xiaomi File Manager", 
+  "oppoFileManager": "OPPO File Manager",
+  "vivoFileManager": "Vivo File Manager",
+  "samsungFileManager": "Samsung File Manager",
+  "useDefaultFileManager": "Use System Default",
+  "useVendorFileManager": "Use Vendor File Manager",
+  "openWithFileManager": "Open with File Manager",
+  "noSuitableFileManagerFound": "No suitable file manager found",
+  "tryAnotherFileManager": "Try another file manager",
   "downloadDirectoryOpened": "Download directory opened",
   "openDownloadDirectoryFailed": "Failed to open download directory: {error}",
   "@openDownloadDirectoryFailed": {

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -408,6 +408,18 @@
       }
     }
   },
+  "selectFileManager": "选择文件管理器",
+  "systemDefault": "系统默认",
+  "huaweiFileManager": "华为文件管理",
+  "xiaomiFileManager": "小米文件管理",
+  "oppoFileManager": "OPPO文件管理",
+  "vivoFileManager": "Vivo文件管理",
+  "samsungFileManager": "三星文件管理",
+  "useDefaultFileManager": "使用系统默认",
+  "useVendorFileManager": "使用厂商文件管理器",
+  "openWithFileManager": "用文件管理器打开",
+  "noSuitableFileManagerFound": "未找到合适的文件管理器",
+  "tryAnotherFileManager": "尝试其他文件管理器",
   "downloadDirectoryOpened": "已打开下载目录",
   "openDownloadDirectoryFailed": "打开下载目录失败: {error}",
   "@openDownloadDirectoryFailed": {

--- a/lib/utils/download_manager.dart
+++ b/lib/utils/download_manager.dart
@@ -500,15 +500,15 @@ class DownloadManager {
           break;
       }
     } catch (e) {
-      log('打开文件异常: $e');
+      log(S.current.openFileFailed(e.toString()));
       getx.Get.showSnackbar(getx.GetSnackBar(
-        message: '打开文件失败: ${e.toString()}',
+        message: S.current.openFileFailed(e.toString()),
         duration: const Duration(seconds: 3),
         mainButton: TextButton(
           onPressed: () {
             _showFileLocation(filePath);
           },
-          child: const Text('查看位置'),
+          child: Text(S.current.viewLocation),
         ),
       ));
     }
@@ -518,35 +518,35 @@ class DownloadManager {
   static void _showFileLocation(String filePath) {
     getx.Get.dialog(
       AlertDialog(
-        title: const Text('文件位置'),
+        title: Text(S.current.fileLocation),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('文件已保存到:'),
+            Text(S.current.fileSavedTo),
             const SizedBox(height: 8),
             SelectableText(
               filePath,
               style: const TextStyle(fontSize: 12),
             ),
             const SizedBox(height: 16),
-            const Text(
-              '您可以使用文件管理器找到此文件，或者尝试安装相应的应用来打开它。',
-              style: TextStyle(fontSize: 14, color: Colors.grey),
+            Text(
+              S.current.fileLocationTip,
+              style: const TextStyle(fontSize: 14, color: Colors.grey),
             ),
           ],
         ),
         actions: [
           TextButton(
             onPressed: () => getx.Get.back(),
-            child: const Text('确定'),
+            child: Text(S.current.confirm),
           ),
           TextButton(
             onPressed: () {
               getx.Get.back();
               _openFileManagerSelector(filePath);
             },
-            child: const Text('打开文件管理器'),
+            child: Text(S.current.openFileManager),
           ),
         ],
       ),
@@ -554,96 +554,20 @@ class DownloadManager {
   }
 
   /// Show file manager selector dialog
-  static void _openFileManagerSelector(String filePath) {
-    // Get directory containing the file
-    String directoryPath = filePath.substring(0, filePath.lastIndexOf('/'));
-    final fileManagerOptions = IntentUtils.getAllFileManagerIntents(directoryPath);
-    
-    getx.Get.dialog(
-      AlertDialog(
-        title: const Row(
-          children: [
-            Icon(Icons.folder_open, size: 24),
-            SizedBox(width: 8),
-            Text('选择文件管理器'),
-          ],
-        ),
-        content: SizedBox(
-          width: double.maxFinite,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // System app chooser
-              ListTile(
-                leading: const Icon(Icons.open_in_new, size: 24, color: Colors.blue),
-                title: const Text('选择应用打开'),
-                subtitle: const Text('让Android系统显示所有可用的应用'),
-                onTap: () async {
-                  getx.Get.back();
-                  await _launchGenericFileManagerChooser(directoryPath);
-                },
-              ),
-              const Divider(),
-              // Vendor file manager options
-              ...fileManagerOptions.take(6).map((option) {
-                return ListTile(
-                  leading: Text(
-                    option['icon'],
-                    style: const TextStyle(fontSize: 20),
-                  ),
-                  title: Text(option['name']),
-                  subtitle: option['isDefault'] == true 
-                      ? const Text('推荐选项')
-                      : null,
-                  onTap: () async {
-                    getx.Get.back();
-                    await _launchFileManagerIntent(option['intent'], option['name']);
-                  },
-                );
-              }).toList(),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => getx.Get.back(),
-            child: const Text('取消'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Launch generic file manager chooser to let user select app
-  static Future<void> _launchGenericFileManagerChooser(String directoryPath) async {
+  static void _openFileManagerSelector(String filePath) async {
     try {
-      final intent = IntentUtils.getGenericFileManagerIntent(directoryPath);
-      await intent.launchChooser('选择应用打开');
-      getx.Get.showSnackbar(const getx.GetSnackBar(
-        message: '已打开应用选择器',
-        duration: Duration(seconds: 2),
-      ));
-    } catch (e) {
-      log('打开文件管理器选择器失败: $e');
+      // Get directory containing the file
+      String directoryPath = filePath.substring(0, filePath.lastIndexOf('/'));
+      final intent = IntentUtils.getFileManagerIntent(directoryPath);
+      await intent.launchChooser(S.current.selectFileManager);
       getx.Get.showSnackbar(getx.GetSnackBar(
-        message: '打开选择器失败: $e',
-        duration: const Duration(seconds: 3),
-      ));
-    }
-  }
-
-  /// Launch specified file manager using Intent
-  static Future<void> _launchFileManagerIntent(dynamic intent, String managerName) async {
-    try {
-      await intent.launch();
-      getx.Get.showSnackbar(getx.GetSnackBar(
-        message: '已打开 $managerName',
+        message: S.current.fileManagerOpened,
         duration: const Duration(seconds: 2),
       ));
     } catch (e) {
-      log('打开 $managerName 失败: $e');
+      log(S.current.openFileManagerFailed('$e'));
       getx.Get.showSnackbar(getx.GetSnackBar(
-        message: '打开 $managerName 失败: $e',
+        message: S.current.openFileManagerFailed('$e'),
         duration: const Duration(seconds: 3),
         backgroundColor: Colors.orange,
       ));

--- a/lib/utils/download_test.dart
+++ b/lib/utils/download_test.dart
@@ -95,7 +95,8 @@ class DownloadTestPage extends StatelessWidget {
               '• 下载过程会显示进度通知\n'
               '• 下载完成后可以选择打开文件\n'
               '• 如果文件名重复会自动添加序号\n'
-              '• 请通过底部导航栏的"下载管理"查看下载文件',
+              '• 请通过底部导航栏的"下载管理"查看下载文件\n'
+              '• 新增：支持厂商定制文件管理器选择',
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ],

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -8,9 +8,8 @@ class IntentUtils {
   /// Create an Intent to open file manager for a specific directory
   static AndroidIntent getFileManagerIntent(String directoryPath) {
     return AndroidIntent(
-      action: "action_view",
-      data: directoryPath,
-      type: "resource/folder",
+      action: "action_main",
+      category: "android.intent.category.APP_FILES",
     );
   }
 

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -7,10 +7,10 @@ class IntentUtils {
 
   /// Create an Intent to open file manager for a specific directory  
   static AndroidIntent getFileManagerIntent(String directoryPath) {
-    // Use a simple intent that should work with most file managers
+    // Open Downloads folder using content URI (Android 7.0+ safe)
     return AndroidIntent(
       action: "action_view",
-      data: "file://$directoryPath",
+      data: "content://com.android.externalstorage.documents/document/primary%3ADownload",
     );
   }
 

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -2,21 +2,24 @@ import 'package:android_intent_plus/android_intent.dart';
 
 class IntentUtils {
   static AndroidIntent getUrlIntent(String url) {
-    return AndroidIntent(action: "action_view", data: url);
+    return AndroidIntent(action: "android.intent.action.VIEW", data: url);
   }
 
-  /// Create an Intent to open file manager for a specific directory
+  /// Create an Intent to open file manager for a specific directory  
   static AndroidIntent getFileManagerIntent(String directoryPath) {
+    // Fallback: try to launch system file manager to Downloads
+    // This should work on most Android devices
     return AndroidIntent(
-      action: "action_main",
+      action: "android.intent.action.MAIN",
       category: "android.intent.category.APP_FILES",
+      flags: [268435456], // FLAG_ACTIVITY_NEW_TASK
     );
   }
 
   /// Create an Intent to show file in file manager
   static AndroidIntent getShowFileInManagerIntent(String filePath) {
     return AndroidIntent(
-      action: "action_view",
+      action: "android.intent.action.VIEW",
       data: "file://$filePath",
       type: _getMimeTypeFromPath(filePath),
     );
@@ -51,7 +54,7 @@ class IntentUtils {
   /// Get generic file manager Intent (let system choose)
   static AndroidIntent getGenericFileManagerIntent(String directoryPath) {
     return AndroidIntent(
-      action: "action_get_content",
+      action: "android.intent.action.GET_CONTENT",
       type: "*/*",
       arguments: {
         'android.intent.extra.LOCAL_ONLY': true,

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -2,24 +2,22 @@ import 'package:android_intent_plus/android_intent.dart';
 
 class IntentUtils {
   static AndroidIntent getUrlIntent(String url) {
-    return AndroidIntent(action: "android.intent.action.VIEW", data: url);
+    return AndroidIntent(action: "action_view", data: url);
   }
 
   /// Create an Intent to open file manager for a specific directory  
   static AndroidIntent getFileManagerIntent(String directoryPath) {
-    // Fallback: try to launch system file manager to Downloads
-    // This should work on most Android devices
+    // Use a simple intent that should work with most file managers
     return AndroidIntent(
-      action: "android.intent.action.MAIN",
-      category: "android.intent.category.APP_FILES",
-      flags: [268435456], // FLAG_ACTIVITY_NEW_TASK
+      action: "action_view",
+      data: "file://$directoryPath",
     );
   }
 
   /// Create an Intent to show file in file manager
   static AndroidIntent getShowFileInManagerIntent(String filePath) {
     return AndroidIntent(
-      action: "android.intent.action.VIEW",
+      action: "action_view",
       data: "file://$filePath",
       type: _getMimeTypeFromPath(filePath),
     );
@@ -54,7 +52,7 @@ class IntentUtils {
   /// Get generic file manager Intent (let system choose)
   static AndroidIntent getGenericFileManagerIntent(String directoryPath) {
     return AndroidIntent(
-      action: "android.intent.action.GET_CONTENT",
+      action: "action_get_content",
       type: "*/*",
       arguments: {
         'android.intent.extra.LOCAL_ONLY': true,

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -9,7 +9,7 @@ class IntentUtils {
   static AndroidIntent getFileManagerIntent(String directoryPath) {
     return AndroidIntent(
       action: "action_view",
-      data: "file://$directoryPath",
+      data: directoryPath,
       type: "resource/folder",
     );
   }
@@ -49,128 +49,15 @@ class IntentUtils {
     }
   }
 
-  /// Create Intent for Huawei file manager
-  static AndroidIntent getHuaweiFileManagerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.huawei.hidisk',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for Xiaomi file manager
-  static AndroidIntent getXiaomiFileManagerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.mi.android.globalFileexplorer',
-      action: 'action_view', 
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for OPPO file manager
-  static AndroidIntent getOppoFileManagerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.coloros.filemanager',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for Vivo file manager
-  static AndroidIntent getVivoFileManagerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.vivo.filemanager',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for Samsung file manager
-  static AndroidIntent getSamsungFileManagerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.sec.android.app.myfiles',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for ES File Explorer
-  static AndroidIntent getESFileExplorerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'com.estrongs.android.pop',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Create Intent for Solid Explorer
-  static AndroidIntent getSolidExplorerIntent(String directoryPath) {
-    return AndroidIntent(
-      package: 'pl.solidexplorer2',
-      action: 'action_view',
-      data: "file://$directoryPath",
-    );
-  }
-
-  /// Get all supported vendor file manager Intent options
-  static List<Map<String, dynamic>> getAllFileManagerIntents(String directoryPath) {
-    return [
-      {
-        'name': '系统默认',
-        'icon': '📁',
-        'intent': getFileManagerIntent(directoryPath),
-        'isDefault': true,
-      },
-      {
-        'name': '华为文件管理',
-        'icon': '🇨🇳',
-        'intent': getHuaweiFileManagerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': '小米文件管理',
-        'icon': '🇨🇳', 
-        'intent': getXiaomiFileManagerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': 'OPPO文件管理',
-        'icon': '🇨🇳',
-        'intent': getOppoFileManagerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': 'Vivo文件管理',
-        'icon': '🇨🇳',
-        'intent': getVivoFileManagerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': '三星文件管理',
-        'icon': '🇰🇷',
-        'intent': getSamsungFileManagerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': 'ES文件浏览器',
-        'icon': '📂',
-        'intent': getESFileExplorerIntent(directoryPath),
-        'isDefault': false,
-      },
-      {
-        'name': 'Solid Explorer',
-        'icon': '📱',
-        'intent': getSolidExplorerIntent(directoryPath),
-        'isDefault': false,
-      },
-    ];
-  }
-
   /// Get generic file manager Intent (let system choose)
   static AndroidIntent getGenericFileManagerIntent(String directoryPath) {
     return AndroidIntent(
-      action: "action_view",
-      data: "file://$directoryPath",
+      action: "action_get_content",
+      type: "*/*",
+      arguments: {
+        'android.intent.extra.LOCAL_ONLY': true,
+        'android.intent.extra.ALLOW_MULTIPLE': false,
+      },
     );
   }
 }

--- a/lib/utils/intent_utils.dart
+++ b/lib/utils/intent_utils.dart
@@ -4,4 +4,173 @@ class IntentUtils {
   static AndroidIntent getUrlIntent(String url) {
     return AndroidIntent(action: "action_view", data: url);
   }
+
+  /// Create an Intent to open file manager for a specific directory
+  static AndroidIntent getFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      action: "action_view",
+      data: "file://$directoryPath",
+      type: "resource/folder",
+    );
+  }
+
+  /// Create an Intent to show file in file manager
+  static AndroidIntent getShowFileInManagerIntent(String filePath) {
+    return AndroidIntent(
+      action: "action_view",
+      data: "file://$filePath",
+      type: _getMimeTypeFromPath(filePath),
+    );
+  }
+
+  /// Get MIME type from file path
+  static String _getMimeTypeFromPath(String filePath) {
+    String extension = filePath.split('.').last.toLowerCase();
+    switch (extension) {
+      case 'pdf':
+        return 'application/pdf';
+      case 'txt':
+        return 'text/plain';
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'apk':
+        return 'application/vnd.android.package-archive';
+      case 'mp4':
+        return 'video/mp4';
+      case 'mp3':
+        return 'audio/mpeg';
+      case 'zip':
+        return 'application/zip';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  /// Create Intent for Huawei file manager
+  static AndroidIntent getHuaweiFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.huawei.hidisk',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for Xiaomi file manager
+  static AndroidIntent getXiaomiFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.mi.android.globalFileexplorer',
+      action: 'action_view', 
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for OPPO file manager
+  static AndroidIntent getOppoFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.coloros.filemanager',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for Vivo file manager
+  static AndroidIntent getVivoFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.vivo.filemanager',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for Samsung file manager
+  static AndroidIntent getSamsungFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.sec.android.app.myfiles',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for ES File Explorer
+  static AndroidIntent getESFileExplorerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'com.estrongs.android.pop',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Create Intent for Solid Explorer
+  static AndroidIntent getSolidExplorerIntent(String directoryPath) {
+    return AndroidIntent(
+      package: 'pl.solidexplorer2',
+      action: 'action_view',
+      data: "file://$directoryPath",
+    );
+  }
+
+  /// Get all supported vendor file manager Intent options
+  static List<Map<String, dynamic>> getAllFileManagerIntents(String directoryPath) {
+    return [
+      {
+        'name': '系统默认',
+        'icon': '📁',
+        'intent': getFileManagerIntent(directoryPath),
+        'isDefault': true,
+      },
+      {
+        'name': '华为文件管理',
+        'icon': '🇨🇳',
+        'intent': getHuaweiFileManagerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': '小米文件管理',
+        'icon': '🇨🇳', 
+        'intent': getXiaomiFileManagerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': 'OPPO文件管理',
+        'icon': '🇨🇳',
+        'intent': getOppoFileManagerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': 'Vivo文件管理',
+        'icon': '🇨🇳',
+        'intent': getVivoFileManagerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': '三星文件管理',
+        'icon': '🇰🇷',
+        'intent': getSamsungFileManagerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': 'ES文件浏览器',
+        'icon': '📂',
+        'intent': getESFileExplorerIntent(directoryPath),
+        'isDefault': false,
+      },
+      {
+        'name': 'Solid Explorer',
+        'icon': '📱',
+        'intent': getSolidExplorerIntent(directoryPath),
+        'isDefault': false,
+      },
+    ];
+  }
+
+  /// Get generic file manager Intent (let system choose)
+  static AndroidIntent getGenericFileManagerIntent(String directoryPath) {
+    return AndroidIntent(
+      action: "action_view",
+      data: "file://$directoryPath",
+    );
+  }
 }


### PR DESCRIPTION
- Added localized strings for various file managers including Huawei, Xiaomi, OPPO, Vivo, and Samsung in both English and Chinese.
- Implemented a dialog to select a file manager when opening files, allowing users to choose from installed file managers or use the system default.
- Updated the download manager to utilize the new file manager selection feature.
- Enhanced the IntentUtils class to create intents for various vendor file managers.
- Improved user experience by providing feedback through snackbars when opening file managers or handling downloads.