### PR TITLE
fix(android): Fix auto-start service not launching on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .history
 .svn/
 migrate_working_dir/
+docs/
 
 # IntelliJ related
 *.iml

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,21 +82,25 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <!-- OpenList后台服务 -->
+        <!-- OpenList background service -->
         <service
             android:name=".OpenListService"
             android:exported="true"
             android:enabled="true"
             android:foregroundServiceType="dataSync"
+            android:directBootAware="true"
+            android:stopWithTask="false"
             tools:ignore="ExportedService" />
 
-        <!-- 开机启动接收器 -->
+        <!-- Boot receiver -->
         <receiver
             android:name=".BootReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            android:directBootAware="true">
             <intent-filter android:priority="1000">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />

--- a/android/app/src/main/kotlin/com/openlist/mobile/BootReceiver.kt
+++ b/android/app/src/main/kotlin/com/openlist/mobile/BootReceiver.kt
@@ -22,9 +22,10 @@ class BootReceiver : BroadcastReceiver() {
         try {
             when (action) {
                 Intent.ACTION_BOOT_COMPLETED,
+                Intent.ACTION_LOCKED_BOOT_COMPLETED,
                 "android.intent.action.QUICKBOOT_POWERON",
                 "com.htc.intent.action.QUICKBOOT_POWERON" -> {
-                    Log.d(TAG, "Boot completed")
+                    Log.d(TAG, "Boot completed (action: $action)")
                     handleBootCompleted(context)
                 }
                 

--- a/android/app/src/main/kotlin/com/openlist/mobile/OpenListService.kt
+++ b/android/app/src/main/kotlin/com/openlist/mobile/OpenListService.kt
@@ -237,10 +237,13 @@ class OpenListService : Service(), OpenList.Listener {
     }
 
     /**
-     * 公共方法：停止OpenList服务
+     * Public method: Stop OpenList service manually
      */
     fun stopOpenListService() {
         if (isRunning) {
+            Log.d(TAG, "User manually stopping service")
+            // Set flag to indicate user manually stopped the service
+            AppConfig.isManuallyStoppedByUser = true
             startOrShutdown()
         }
     }
@@ -274,6 +277,8 @@ class OpenListService : Service(), OpenList.Listener {
             }
         } else {
             Log.d(TAG, "Starting OpenList from user action")
+            // Clear manual stop flag when user manually starts the service
+            AppConfig.isManuallyStoppedByUser = false
             startOpenListBackend(fromBoot = false)
         }
     }


### PR DESCRIPTION
## Problem
The OpenList service was not automatically starting after device boot, causing the auto-start feature to fail completely.

## Root Causes
- OpenList native library not initialized before boot startup
- Missing distinction between user manual stop and system stop
- Incomplete boot receiver intent handling
- No support for Direct Boot mode on encrypted devices
- Potential ANR if foreground notification creation was slow

## Changes
- **BootReceiver**: Enhanced boot detection, added support for `LOCKED_BOOT_COMPLETED`
- **OpenListService**: Refactored startup logic with proper initialization sequence
- **App**: Added early OpenList library initialization
- **Manual Stop Flag**: Proper tracking of user intent to prevent unwanted auto-starts
- **Notification**: Added fallback mechanism to prevent service crashes
- **AndroidManifest**: Added Direct Boot support and `stopWithTask=false`