### PR TITLE
fix(download): support WebView blob downloads

### DIFF
--- a/lib/pages/web/web.dart
+++ b/lib/pages/web/web.dart
@@ -50,6 +50,7 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
   String _url = "http://localhost:5244";
   bool _canGoBack = false;
   bool _isLoading = false;
+  int _activeBlobDownloads = 0;
 
   static const int _blobChunkSize = 128 * 1024;
   static final UnmodifiableListView<UserScript> _blobDownloadScripts =
@@ -115,6 +116,13 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
 
   bool _isAllowedInAppNavigation(Uri uri) {
     final scheme = uri.scheme.toLowerCase();
+
+    if (scheme == "blob") {
+      final source = Uri.tryParse(uri.toString().substring("blob:".length));
+      return source != null &&
+          (source.scheme == "http" || source.scheme == "https") &&
+          _isLoopbackHost(source.host);
+    }
 
     if (_inAppSafeSchemes.contains(scheme)) {
       return true;
@@ -232,6 +240,9 @@ window.__openListReleaseBlobDownload?.(url);
     DownloadStartRequest request,
   ) async {
     final url = request.url.toString();
+    setState(() {
+      _activeBlobDownloads++;
+    });
     try {
       final metadata = await _initializeBlobTransfer(controller, url);
       final size = (metadata["size"] as num).toInt();
@@ -252,6 +263,13 @@ window.__openListReleaseBlobDownload?.(url);
         backgroundColor: Colors.red,
       ));
     } finally {
+      if (mounted) {
+        setState(() {
+          _activeBlobDownloads--;
+        });
+      } else {
+        _activeBlobDownloads--;
+      }
       try {
         await _releaseBlobTransfer(controller, url);
       } catch (error) {
@@ -262,7 +280,9 @@ window.__openListReleaseBlobDownload?.(url);
 
   onClickNavigationBar() {
     log("onClickNavigationBar");
-    _webViewController?.reload();
+    if (_activeBlobDownloads == 0) {
+      _webViewController?.reload();
+    }
   }
 
   @override
@@ -336,11 +356,13 @@ window.__openListReleaseBlobDownload?.(url);
   @override
   Widget build(BuildContext context) {
     return PopScope(
-        canPop: !_canGoBack,
+        canPop: _activeBlobDownloads == 0 && !_canGoBack,
         onPopInvoked: (didPop) async {
           log("onPopInvoked $didPop");
           if (didPop) return;
-          _webViewController?.goBack();
+          if (_activeBlobDownloads == 0) {
+            _webViewController?.goBack();
+          }
         },
         child: Scaffold(
           body: Column(children: <Widget>[
@@ -374,6 +396,10 @@ window.__openListReleaseBlobDownload?.(url);
                     return NavigationActionPolicy.CANCEL;
                   }
 
+                  if (_activeBlobDownloads > 0 && uri.scheme != "blob") {
+                    return NavigationActionPolicy.CANCEL;
+                  }
+
                   if (_isAllowedInAppNavigation(uri)) {
                     return NavigationActionPolicy.ALLOW;
                   }
@@ -401,7 +427,9 @@ window.__openListReleaseBlobDownload?.(url);
                         await Future.delayed(const Duration(milliseconds: 500));
                         if (await Android().isRunning()) {
                           log("Service started, reloading WebView");
-                          _webViewController?.reload();
+                          if (_activeBlobDownloads == 0) {
+                            _webViewController?.reload();
+                          }
                           break;
                         }
                       }

--- a/lib/pages/web/web.dart
+++ b/lib/pages/web/web.dart
@@ -270,7 +270,7 @@ window.__openListReleaseBlobDownload?.(url);
     super.initState();
     // Register lifecycle observer to handle app state changes
     WidgetsBinding.instance.addObserver(this);
-
+    
     // Get OpenList HTTP port
     Android()
         .getOpenListHttpPort()
@@ -305,7 +305,7 @@ window.__openListReleaseBlobDownload?.(url);
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     log("App lifecycle state changed: $state");
-
+    
     switch (state) {
       case AppLifecycleState.resumed:
         // App returned to foreground, WebView should be active
@@ -389,7 +389,7 @@ window.__openListReleaseBlobDownload?.(url);
                 },
                 onReceivedError: (controller, request, error) async {
                   log("WebView error: ${error.description}");
-
+                  
                   // Check if OpenList service is running
                   try {
                     if (!await Android().isRunning()) {
@@ -425,29 +425,29 @@ window.__openListReleaseBlobDownload?.(url);
                           if (isBlob) {
                             await _downloadBlob(controller, request);
                           } else {
-                            DownloadManager.downloadFileInBackground(
+                          DownloadManager.downloadFileInBackground(
                               url: request.url.toString(),
                               filename: request.suggestedFilename,
-                            );
+                          );
                           }
                         },
                         child: Text(S.of(context).directDownload),
                       ),
                       if (!isBlob) ...[
-                        TextButton(
-                          onPressed: () {
+                      TextButton(
+                        onPressed: () {
                             IntentUtils.getUrlIntent(request.url.toString())
-                                .launchChooser(S.of(context).selectAppToOpen);
-                          },
-                          child: Text(S.of(context).selectAppToOpen),
-                        ),
-                        TextButton(
-                          onPressed: () {
+                              .launchChooser(S.of(context).selectAppToOpen);
+                        },
+                        child: Text(S.of(context).selectAppToOpen),
+                      ),
+                      TextButton(
+                        onPressed: () {
                             IntentUtils.getUrlIntent(request.url.toString())
                                 .launch();
-                          },
-                          child: Text(S.of(context).browserDownload),
-                        ),
+                        },
+                        child: Text(S.of(context).browserDownload),
+                      ),
                       ],
                     ]),
                     onTap: isBlob
@@ -456,12 +456,12 @@ window.__openListReleaseBlobDownload?.(url);
                             Clipboard.setData(ClipboardData(
                               text: request.url.toString(),
                             ));
-                            Get.closeCurrentSnackbar();
-                            Get.showSnackbar(GetSnackBar(
-                              message: S.of(context).copiedToClipboard,
-                              duration: const Duration(seconds: 1),
-                            ));
-                          },
+                      Get.closeCurrentSnackbar();
+                      Get.showSnackbar(GetSnackBar(
+                        message: S.of(context).copiedToClipboard,
+                        duration: const Duration(seconds: 1),
+                      ));
+                    },
                   ));
                 },
                 onLoadStop:

--- a/lib/pages/web/web.dart
+++ b/lib/pages/web/web.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:io' show Platform;
 
@@ -49,6 +51,55 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
   bool _canGoBack = false;
   bool _isLoading = false;
 
+  static const int _blobChunkSize = 128 * 1024;
+  static final UnmodifiableListView<UserScript> _blobDownloadScripts =
+      UnmodifiableListView([
+    UserScript(
+      source: r'''
+(() => {
+  if (!["localhost", "127.0.0.1", "::1"].includes(location.hostname)) return;
+  if (window.__openListBlobDownloads) return;
+
+  const downloads = new Map();
+  const originalClick = HTMLAnchorElement.prototype.click;
+  const originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+
+  const release = (url) => {
+    const entry = downloads.get(url);
+    if (entry) clearTimeout(entry.timeout);
+    downloads.delete(url);
+    originalRevokeObjectURL(url);
+  };
+
+  HTMLAnchorElement.prototype.click = function() {
+    const url = this.href;
+    if (this.download && url.startsWith("blob:")) {
+      const previous = downloads.get(url);
+      if (previous) clearTimeout(previous.timeout);
+
+      const entry = {
+        blob: fetch(url).then((response) => response.blob()),
+        timeout: null,
+      };
+      entry.timeout = setTimeout(() => release(url), 30000);
+      downloads.set(url, entry);
+    }
+    return originalClick.call(this);
+  };
+
+  URL.revokeObjectURL = (url) => {
+    if (!downloads.has(url)) originalRevokeObjectURL(url);
+  };
+
+  window.__openListBlobDownloads = downloads;
+  window.__openListBlobTransfers = downloads;
+  window.__openListReleaseBlobDownload = release;
+})();
+''',
+      injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+    ),
+  ]);
+
   static const Set<String> _inAppSafeSchemes = {
     "about",
     "data",
@@ -99,6 +150,116 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
         )));
   }
 
+  Future<Map<String, dynamic>> _initializeBlobTransfer(
+    InAppWebViewController controller,
+    String url,
+  ) async {
+    final result = await controller.callAsyncJavaScript(
+      functionBody: r'''
+const entry = window.__openListBlobDownloads?.get(url);
+if (!entry) throw "Blob download is no longer available";
+
+clearTimeout(entry.timeout);
+const blob = await entry.blob;
+window.__openListBlobTransfers.set(url, blob);
+return {size: blob.size, type: blob.type};
+''',
+      arguments: {"url": url},
+      contentWorld: ContentWorld.PAGE,
+    );
+
+    if (result?.error != null) {
+      throw StateError(result!.error!);
+    }
+    if (result?.value is! Map) {
+      throw StateError("Failed to initialize Blob download");
+    }
+    return Map<String, dynamic>.from(result!.value as Map);
+  }
+
+  Future<List<int>> _readBlobChunk(
+    InAppWebViewController controller,
+    String url,
+    int offset,
+  ) async {
+    final result = await controller.callAsyncJavaScript(
+      functionBody: r'''
+const blob = window.__openListBlobTransfers?.get(url);
+if (!blob) throw "Blob download is no longer available";
+
+const bytes = new Uint8Array(
+  await blob.slice(offset, offset + chunkSize).arrayBuffer(),
+);
+let binary = "";
+for (let i = 0; i < bytes.length; i += 0x8000) {
+  binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+}
+return btoa(binary);
+''',
+      arguments: {
+        "url": url,
+        "offset": offset,
+        "chunkSize": _blobChunkSize,
+      },
+      contentWorld: ContentWorld.PAGE,
+    );
+
+    if (result?.error != null) {
+      throw StateError(result!.error!);
+    }
+    if (result?.value is! String) {
+      throw StateError("Failed to read Blob download");
+    }
+    return base64Decode(result!.value as String);
+  }
+
+  Future<void> _releaseBlobTransfer(
+    InAppWebViewController controller,
+    String url,
+  ) async {
+    await controller.callAsyncJavaScript(
+      functionBody: r'''
+window.__openListBlobTransfers?.delete(url);
+window.__openListReleaseBlobDownload?.(url);
+''',
+      arguments: {"url": url},
+      contentWorld: ContentWorld.PAGE,
+    );
+  }
+
+  Future<void> _downloadBlob(
+    InAppWebViewController controller,
+    DownloadStartRequest request,
+  ) async {
+    final url = request.url.toString();
+    try {
+      final metadata = await _initializeBlobTransfer(controller, url);
+      final size = (metadata["size"] as num).toInt();
+      final saved = await DownloadManager.saveFileInBackground(
+        source: url,
+        filename: request.suggestedFilename,
+        totalBytes: size,
+        readChunk: (offset) => _readBlobChunk(controller, url, offset),
+      );
+      if (!saved) return;
+    } catch (error) {
+      log("Blob download failed: $error");
+      Get.showSnackbar(GetSnackBar(
+        message: S.current.downloadFailedFile(
+          request.suggestedFilename ?? "download",
+        ),
+        duration: const Duration(seconds: 3),
+        backgroundColor: Colors.red,
+      ));
+    } finally {
+      try {
+        await _releaseBlobTransfer(controller, url);
+      } catch (error) {
+        log("Failed to release Blob download: $error");
+      }
+    }
+  }
+
   onClickNavigationBar() {
     log("onClickNavigationBar");
     _webViewController?.reload();
@@ -109,7 +270,7 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
     super.initState();
     // Register lifecycle observer to handle app state changes
     WidgetsBinding.instance.addObserver(this);
-    
+
     // Get OpenList HTTP port
     Android()
         .getOpenListHttpPort()
@@ -144,7 +305,7 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     log("App lifecycle state changed: $state");
-    
+
     switch (state) {
       case AppLifecycleState.resumed:
         // App returned to foreground, WebView should be active
@@ -192,6 +353,7 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
             Expanded(
               child: InAppWebView(
                 initialSettings: settings,
+                initialUserScripts: _blobDownloadScripts,
                 initialUrlRequest: URLRequest(url: WebUri(_url)),
                 onWebViewCreated: (InAppWebViewController controller) {
                   _webViewController = controller;
@@ -227,7 +389,7 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
                 },
                 onReceivedError: (controller, request, error) async {
                   log("WebView error: ${error.description}");
-                  
+
                   // Check if OpenList service is running
                   try {
                     if (!await Android().isRunning()) {
@@ -248,48 +410,58 @@ class WebScreenState extends State<WebScreen> with WidgetsBindingObserver {
                     log("Failed to handle WebView error: $e");
                   }
                 },
-                onDownloadStartRequest: (controller, url) async {
+                onDownloadStartRequest: (controller, request) async {
+                  final isBlob = request.url.scheme == "blob";
                   Get.showSnackbar(GetSnackBar(
                     title: S.of(context).downloadThisFile,
-                    message: url.suggestedFilename ??
-                        url.contentDisposition ??
-                        url.toString(),
+                    message: request.suggestedFilename ??
+                        request.contentDisposition ??
+                        request.toString(),
                     duration: const Duration(seconds: 5),
                     mainButton: Column(children: [
                       TextButton(
                         onPressed: () async {
                           Get.closeCurrentSnackbar();
-                          // 使用内置下载管理器后台下载
-                          DownloadManager.downloadFileInBackground(
-                            url: url.url.toString(),
-                            filename: url.suggestedFilename,
-                          );
+                          if (isBlob) {
+                            await _downloadBlob(controller, request);
+                          } else {
+                            DownloadManager.downloadFileInBackground(
+                              url: request.url.toString(),
+                              filename: request.suggestedFilename,
+                            );
+                          }
                         },
                         child: Text(S.of(context).directDownload),
                       ),
-                      TextButton(
-                        onPressed: () {
-                          IntentUtils.getUrlIntent(url.url.toString())
-                              .launchChooser(S.of(context).selectAppToOpen);
-                        },
-                        child: Text(S.of(context).selectAppToOpen),
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          IntentUtils.getUrlIntent(url.url.toString()).launch();
-                        },
-                        child: Text(S.of(context).browserDownload),
-                      ),
+                      if (!isBlob) ...[
+                        TextButton(
+                          onPressed: () {
+                            IntentUtils.getUrlIntent(request.url.toString())
+                                .launchChooser(S.of(context).selectAppToOpen);
+                          },
+                          child: Text(S.of(context).selectAppToOpen),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            IntentUtils.getUrlIntent(request.url.toString())
+                                .launch();
+                          },
+                          child: Text(S.of(context).browserDownload),
+                        ),
+                      ],
                     ]),
-                    onTap: (_) {
-                      Clipboard.setData(
-                          ClipboardData(text: url.url.toString()));
-                      Get.closeCurrentSnackbar();
-                      Get.showSnackbar(GetSnackBar(
-                        message: S.of(context).copiedToClipboard,
-                        duration: const Duration(seconds: 1),
-                      ));
-                    },
+                    onTap: isBlob
+                        ? null
+                        : (_) {
+                            Clipboard.setData(ClipboardData(
+                              text: request.url.toString(),
+                            ));
+                            Get.closeCurrentSnackbar();
+                            Get.showSnackbar(GetSnackBar(
+                              message: S.of(context).copiedToClipboard,
+                              duration: const Duration(seconds: 1),
+                            ));
+                          },
                   ));
                 },
                 onLoadStop:

--- a/lib/utils/download_manager.dart
+++ b/lib/utils/download_manager.dart
@@ -83,6 +83,8 @@ class DownloadManager {
   static final Map<String, DownloadTask> _activeTasks = {};
   static final List<DownloadTask> _completedTasks = [];
   static final Set<String> _cancelledTaskIds = {};
+  static final Set<String> _reservedFilePaths = {};
+  static int _nextTaskId = 0;
   
   /// 获取所有活跃的下载任务
   static List<DownloadTask> get activeTasks => _activeTasks.values.toList();
@@ -118,6 +120,7 @@ class DownloadManager {
     String finalFilename = filename ?? _getFilenameFromUrl(url);
     String filePath = '${downloadDir.path}/$finalFilename';
     filePath = _getUniqueFilePath(filePath);
+    _reservedFilePaths.add(filePath);
     finalFilename = filePath.split('/').last;
 
     // 创建下载任务
@@ -228,6 +231,8 @@ class DownloadManager {
       }
       
       return false;
+    } finally {
+      _reservedFilePaths.remove(filePath);
     }
   }
 
@@ -268,7 +273,7 @@ class DownloadManager {
 
     await NotificationManager.initialize();
 
-    final taskId = DateTime.now().millisecondsSinceEpoch.toString();
+    final taskId = '${DateTime.now().millisecondsSinceEpoch}-${_nextTaskId++}';
     final downloadDir = await _getOpenListDownloadDirectory();
     if (downloadDir == null) {
       getx.Get.showSnackbar(getx.GetSnackBar(
@@ -280,8 +285,9 @@ class DownloadManager {
 
     var finalFilename = filename ?? _getFilenameFromUrl(source);
     var filePath = _getUniqueFilePath('${downloadDir.path}/$finalFilename');
+    _reservedFilePaths.add(filePath);
     finalFilename = filePath.split('/').last;
-    final temporaryFile = File('$filePath.part');
+    final temporaryFile = File('$filePath.$taskId.part');
     final task = DownloadTask(
       id: taskId,
       url: source,
@@ -322,9 +328,19 @@ class DownloadManager {
         await NotificationManager.showDownloadProgressNotification();
       }
 
+      if (_cancelledTaskIds.contains(taskId)) {
+        throw const FileSystemException('Download cancelled');
+      }
       await output.close();
       output = null;
+      if (_cancelledTaskIds.contains(taskId)) {
+        throw const FileSystemException('Download cancelled');
+      }
       await temporaryFile.rename(filePath);
+      if (_cancelledTaskIds.contains(taskId)) {
+        await File(filePath).delete();
+        throw const FileSystemException('Download cancelled');
+      }
 
       task.status = DownloadStatus.completed;
       task.endTime = DateTime.now();
@@ -353,9 +369,17 @@ class DownloadManager {
       _activeTasks.remove(taskId);
       _completedTasks.insert(0, task);
 
-      await output?.close();
-      if (await temporaryFile.exists()) {
-        await temporaryFile.delete();
+      try {
+        await output?.close();
+      } catch (closeError) {
+        log('关闭临时下载文件失败: $closeError');
+      }
+      try {
+        if (await temporaryFile.exists()) {
+          await temporaryFile.delete();
+        }
+      } catch (deleteError) {
+        log('删除临时下载文件失败: $deleteError');
       }
 
       if (task.status == DownloadStatus.failed) {
@@ -375,6 +399,7 @@ class DownloadManager {
       return false;
     } finally {
       _cancelledTaskIds.remove(taskId);
+      _reservedFilePaths.remove(filePath);
     }
   }
 
@@ -474,7 +499,7 @@ class DownloadManager {
   /// 获取唯一的文件路径（避免重名）
   static String _getUniqueFilePath(String originalPath) {
     File file = File(originalPath);
-    if (!file.existsSync()) {
+    if (!file.existsSync() && !_reservedFilePaths.contains(originalPath)) {
       return originalPath;
     }
 
@@ -489,7 +514,7 @@ class DownloadManager {
     do {
       newPath = '$directory/${nameWithoutExtension}_$counter$extension';
       counter++;
-    } while (File(newPath).existsSync());
+    } while (File(newPath).existsSync() || _reservedFilePaths.contains(newPath));
 
     return newPath;
   }

--- a/lib/utils/download_manager.dart
+++ b/lib/utils/download_manager.dart
@@ -82,13 +82,14 @@ class DownloadManager {
   static final Dio _dio = Dio();
   static final Map<String, DownloadTask> _activeTasks = {};
   static final List<DownloadTask> _completedTasks = [];
-  
+  static final Set<String> _cancelledTaskIds = {};
+
   /// 获取所有活跃的下载任务
   static List<DownloadTask> get activeTasks => _activeTasks.values.toList();
-  
+
   /// 获取所有已完成的下载任务
   static List<DownloadTask> get completedTasks => _completedTasks;
-  
+
   /// 获取所有下载任务
   static List<DownloadTask> get allTasks => [..._activeTasks.values, ..._completedTasks];
 
@@ -99,10 +100,10 @@ class DownloadManager {
   }) async {
     // 初始化通知管理器
     await NotificationManager.initialize();
-    
+
     // 生成任务ID
     String taskId = DateTime.now().millisecondsSinceEpoch.toString();
-    
+
     // 获取下载目录
     Directory? downloadDir = await _getOpenListDownloadDirectory();
     if (downloadDir == null) {
@@ -143,10 +144,10 @@ class DownloadManager {
     try {
       // 更新任务状态
       task.status = DownloadStatus.downloading;
-      
+
       // 显示初始通知
       await NotificationManager.showDownloadProgressNotification();
-      
+
       // 执行下载
       await _dio.download(
         url,
@@ -154,16 +155,16 @@ class DownloadManager {
         cancelToken: cancelToken,
         onReceiveProgress: (received, total) {
           if (task.status == DownloadStatus.cancelled) return;
-          
+
           task.receivedBytes = received;
           task.totalBytes = total;
           if (total > 0) {
             task.progress = received / total;
           }
-          
+
           // 更新通知进度
           NotificationManager.showDownloadProgressNotification();
-          
+
           log('下载进度: ${(task.progress * 100).toStringAsFixed(1)}%');
         },
       );
@@ -195,7 +196,6 @@ class DownloadManager {
 
       log('文件下载完成: $filePath');
       return true;
-
     } catch (e) {
       if (e is DioException && e.type == DioExceptionType.cancel) {
         // 用户取消下载
@@ -208,7 +208,7 @@ class DownloadManager {
         task.errorMessage = e.toString();
         task.endTime = DateTime.now();
         log('下载失败: $e');
-        
+
         getx.Get.showSnackbar(getx.GetSnackBar(
           message: S.current.downloadFailedFile(finalFilename),
           duration: const Duration(seconds: 3),
@@ -219,14 +219,14 @@ class DownloadManager {
       // 移动到已完成列表
       _activeTasks.remove(taskId);
       _completedTasks.insert(0, task);
-      
+
       // 更新通知状态
       if (_activeTasks.isEmpty) {
         await NotificationManager.cancelDownloadNotification();
       } else {
         await NotificationManager.showDownloadProgressNotification();
       }
-      
+
       return false;
     }
   }
@@ -242,11 +242,151 @@ class DownloadManager {
     );
   }
 
+  static Future<bool> saveFileInBackground({
+    required String source,
+    required int totalBytes,
+    required Future<List<int>> Function(int offset) readChunk,
+    String? filename,
+  }) async {
+    if (Platform.isAndroid) {
+      var storageStatus = await Permission.storage.status;
+      var manageStorageStatus = await Permission.manageExternalStorage.status;
+      if (!storageStatus.isGranted) {
+        storageStatus = await Permission.storage.request();
+      }
+      if (!manageStorageStatus.isGranted) {
+        manageStorageStatus = await Permission.manageExternalStorage.request();
+      }
+      if (!storageStatus.isGranted && !manageStorageStatus.isGranted) {
+        getx.Get.showSnackbar(getx.GetSnackBar(
+          message: S.current.grantStoragePermissionDesc,
+          duration: const Duration(seconds: 5),
+        ));
+        return false;
+      }
+    }
+
+    await NotificationManager.initialize();
+
+    final taskId = DateTime.now().millisecondsSinceEpoch.toString();
+    final downloadDir = await _getOpenListDownloadDirectory();
+    if (downloadDir == null) {
+      getx.Get.showSnackbar(getx.GetSnackBar(
+        message: S.current.cannotGetDownloadDirectory,
+        duration: const Duration(seconds: 3),
+      ));
+      return false;
+    }
+
+    var finalFilename = filename ?? _getFilenameFromUrl(source);
+    var filePath = _getUniqueFilePath('${downloadDir.path}/$finalFilename');
+    finalFilename = filePath.split('/').last;
+    final temporaryFile = File('$filePath.part');
+    final task = DownloadTask(
+      id: taskId,
+      url: source,
+      filename: finalFilename,
+      filePath: filePath,
+      totalBytes: totalBytes,
+    );
+    _activeTasks[taskId] = task;
+
+    getx.Get.showSnackbar(getx.GetSnackBar(
+      message: S.current.startDownloadFile(finalFilename),
+      duration: const Duration(seconds: 2),
+      backgroundColor: Colors.green,
+    ));
+
+    RandomAccessFile? output;
+    try {
+      task.status = DownloadStatus.downloading;
+      await NotificationManager.showDownloadProgressNotification();
+
+      output = await temporaryFile.open(mode: FileMode.write);
+      while (task.receivedBytes < totalBytes) {
+        if (_cancelledTaskIds.contains(taskId)) {
+          throw const FileSystemException('Download cancelled');
+        }
+
+        final chunk = await readChunk(task.receivedBytes);
+        if (_cancelledTaskIds.contains(taskId)) {
+          throw const FileSystemException('Download cancelled');
+        }
+        if (chunk.isEmpty || task.receivedBytes + chunk.length > totalBytes) {
+          throw const FormatException('Invalid Blob download data');
+        }
+
+        await output.writeFrom(chunk);
+        task.receivedBytes += chunk.length;
+        task.progress = totalBytes == 0 ? 1 : task.receivedBytes / totalBytes;
+        await NotificationManager.showDownloadProgressNotification();
+      }
+
+      await output.close();
+      output = null;
+      await temporaryFile.rename(filePath);
+
+      task.status = DownloadStatus.completed;
+      task.endTime = DateTime.now();
+      task.progress = 1.0;
+      _activeTasks.remove(taskId);
+      _completedTasks.insert(0, task);
+
+      await NotificationManager.showSingleFileCompleteNotification(task);
+      getx.Get.showSnackbar(getx.GetSnackBar(
+        message: S.current.downloadCompleteFile(finalFilename),
+        duration: const Duration(seconds: 3),
+        backgroundColor: Colors.blue,
+        mainButton: TextButton(
+          onPressed: () => _openFile(filePath),
+          child: Text(S.current.open),
+        ),
+      ));
+      log('文件下载完成: $filePath');
+      return true;
+    } catch (error) {
+      task.status = _cancelledTaskIds.contains(taskId)
+          ? DownloadStatus.cancelled
+          : DownloadStatus.failed;
+      task.errorMessage = error.toString();
+      task.endTime = DateTime.now();
+      _activeTasks.remove(taskId);
+      _completedTasks.insert(0, task);
+
+      await output?.close();
+      if (await temporaryFile.exists()) {
+        await temporaryFile.delete();
+      }
+
+      if (task.status == DownloadStatus.failed) {
+        log('下载失败: $error');
+        getx.Get.showSnackbar(getx.GetSnackBar(
+          message: S.current.downloadFailedFile(finalFilename),
+          duration: const Duration(seconds: 3),
+          backgroundColor: Colors.red,
+        ));
+      }
+
+      if (_activeTasks.isEmpty) {
+        await NotificationManager.cancelDownloadNotification();
+      } else {
+        await NotificationManager.showDownloadProgressNotification();
+      }
+      return false;
+    } finally {
+      _cancelledTaskIds.remove(taskId);
+    }
+  }
+
   /// 取消下载任务
   static void cancelDownload(String taskId) {
     DownloadTask? task = _activeTasks[taskId];
-    if (task != null && task.cancelToken != null) {
-      task.cancelToken!.cancel(S.current.userCancelledDownloadError);
+    if (task != null) {
+      if (task.cancelToken != null) {
+        task.cancelToken!.cancel(S.current.userCancelledDownloadError);
+      } else {
+        _cancelledTaskIds.add(taskId);
+      }
     }
   }
 
@@ -265,7 +405,7 @@ class DownloadManager {
   static Future<Directory?> _getOpenListDownloadDirectory() async {
     try {
       Directory? baseDir;
-      
+
       if (Platform.isAndroid) {
         // Android: 优先使用公共下载目录
         baseDir = Directory('/storage/emulated/0/Download');
@@ -292,7 +432,7 @@ class DownloadManager {
 
       // 创建OpenList专用文件夹
       Directory openListDir = Directory('${baseDir.path}/OpenList');
-      
+
       if (!await openListDir.exists()) {
         try {
           await openListDir.create(recursive: true);
@@ -306,7 +446,6 @@ class DownloadManager {
 
       log('OpenList下载目录: ${openListDir.path}');
       return openListDir;
-      
     } catch (e) {
       log('获取下载目录失败: $e');
       return null;
@@ -327,7 +466,7 @@ class DownloadManager {
     } catch (e) {
       log('解析文件名失败: $e');
     }
-    
+
     // 如果无法从URL提取文件名，使用时间戳
     return 'download_${DateTime.now().millisecondsSinceEpoch}';
   }
@@ -341,8 +480,8 @@ class DownloadManager {
 
     String directory = file.parent.path;
     String nameWithoutExtension = file.path.split('/').last.split('.').first;
-    String extension = file.path.contains('.') 
-        ? '.${file.path.split('.').last}' 
+    String extension = file.path.contains('.')
+        ? '.${file.path.split('.').last}'
         : '';
 
     int counter = 1;
@@ -363,15 +502,15 @@ class DownloadManager {
   /// 检查和请求安装权限
   static Future<bool> _checkInstallPermission() async {
     if (!Platform.isAndroid) return true;
-    
+
     try {
       // 检查是否有安装权限
       bool hasPermission = await Permission.requestInstallPackages.isGranted;
-      
+
       if (!hasPermission) {
         // 请求安装权限
         PermissionStatus status = await Permission.requestInstallPackages.request();
-        
+
         if (status.isGranted) {
           return true;
         } else if (status.isPermanentlyDenied) {
@@ -404,7 +543,7 @@ class DownloadManager {
           return false;
         }
       }
-      
+
       return true;
     } catch (e) {
       log('检查安装权限失败: $e');
@@ -416,7 +555,7 @@ class DownloadManager {
   static Future<void> _openFile(String filePath) async {
     try {
       log('尝试打开文件: $filePath');
-      
+
       // 如果是 APK 文件，先检查安装权限
       if (_isApkFile(filePath)) {
         bool hasPermission = await _checkInstallPermission();
@@ -424,12 +563,12 @@ class DownloadManager {
           return; // 没有权限，不继续打开
         }
       }
-      
+
       // 使用 open_filex 插件打开文件
       final result = await OpenFilex.open(filePath);
-      
+
       log('打开文件结果: ${result.type} - ${result.message}');
-      
+
       // 根据结果显示相应的提示
       switch (result.type) {
         case ResultType.done:
@@ -610,7 +749,7 @@ class DownloadController extends getx.GetxController {
 
   void updateProgress(double progress, int received, int total) {
     if (_isCancelled) return;
-    
+
     _progress = progress;
     _statusText = '${_formatBytes(received)} / ${_formatBytes(total)}';
     update();

--- a/lib/utils/download_manager.dart
+++ b/lib/utils/download_manager.dart
@@ -83,13 +83,13 @@ class DownloadManager {
   static final Map<String, DownloadTask> _activeTasks = {};
   static final List<DownloadTask> _completedTasks = [];
   static final Set<String> _cancelledTaskIds = {};
-
+  
   /// 获取所有活跃的下载任务
   static List<DownloadTask> get activeTasks => _activeTasks.values.toList();
-
+  
   /// 获取所有已完成的下载任务
   static List<DownloadTask> get completedTasks => _completedTasks;
-
+  
   /// 获取所有下载任务
   static List<DownloadTask> get allTasks => [..._activeTasks.values, ..._completedTasks];
 
@@ -100,10 +100,10 @@ class DownloadManager {
   }) async {
     // 初始化通知管理器
     await NotificationManager.initialize();
-
+    
     // 生成任务ID
     String taskId = DateTime.now().millisecondsSinceEpoch.toString();
-
+    
     // 获取下载目录
     Directory? downloadDir = await _getOpenListDownloadDirectory();
     if (downloadDir == null) {
@@ -144,10 +144,10 @@ class DownloadManager {
     try {
       // 更新任务状态
       task.status = DownloadStatus.downloading;
-
+      
       // 显示初始通知
       await NotificationManager.showDownloadProgressNotification();
-
+      
       // 执行下载
       await _dio.download(
         url,
@@ -155,16 +155,16 @@ class DownloadManager {
         cancelToken: cancelToken,
         onReceiveProgress: (received, total) {
           if (task.status == DownloadStatus.cancelled) return;
-
+          
           task.receivedBytes = received;
           task.totalBytes = total;
           if (total > 0) {
             task.progress = received / total;
           }
-
+          
           // 更新通知进度
           NotificationManager.showDownloadProgressNotification();
-
+          
           log('下载进度: ${(task.progress * 100).toStringAsFixed(1)}%');
         },
       );
@@ -208,7 +208,7 @@ class DownloadManager {
         task.errorMessage = e.toString();
         task.endTime = DateTime.now();
         log('下载失败: $e');
-
+        
         getx.Get.showSnackbar(getx.GetSnackBar(
           message: S.current.downloadFailedFile(finalFilename),
           duration: const Duration(seconds: 3),
@@ -219,14 +219,14 @@ class DownloadManager {
       // 移动到已完成列表
       _activeTasks.remove(taskId);
       _completedTasks.insert(0, task);
-
+      
       // 更新通知状态
       if (_activeTasks.isEmpty) {
         await NotificationManager.cancelDownloadNotification();
       } else {
         await NotificationManager.showDownloadProgressNotification();
       }
-
+      
       return false;
     }
   }
@@ -383,7 +383,7 @@ class DownloadManager {
     DownloadTask? task = _activeTasks[taskId];
     if (task != null) {
       if (task.cancelToken != null) {
-        task.cancelToken!.cancel(S.current.userCancelledDownloadError);
+      task.cancelToken!.cancel(S.current.userCancelledDownloadError);
       } else {
         _cancelledTaskIds.add(taskId);
       }
@@ -405,7 +405,7 @@ class DownloadManager {
   static Future<Directory?> _getOpenListDownloadDirectory() async {
     try {
       Directory? baseDir;
-
+      
       if (Platform.isAndroid) {
         // Android: 优先使用公共下载目录
         baseDir = Directory('/storage/emulated/0/Download');
@@ -432,7 +432,7 @@ class DownloadManager {
 
       // 创建OpenList专用文件夹
       Directory openListDir = Directory('${baseDir.path}/OpenList');
-
+      
       if (!await openListDir.exists()) {
         try {
           await openListDir.create(recursive: true);
@@ -466,7 +466,7 @@ class DownloadManager {
     } catch (e) {
       log('解析文件名失败: $e');
     }
-
+    
     // 如果无法从URL提取文件名，使用时间戳
     return 'download_${DateTime.now().millisecondsSinceEpoch}';
   }
@@ -480,8 +480,8 @@ class DownloadManager {
 
     String directory = file.parent.path;
     String nameWithoutExtension = file.path.split('/').last.split('.').first;
-    String extension = file.path.contains('.')
-        ? '.${file.path.split('.').last}'
+    String extension = file.path.contains('.') 
+        ? '.${file.path.split('.').last}' 
         : '';
 
     int counter = 1;
@@ -502,15 +502,15 @@ class DownloadManager {
   /// 检查和请求安装权限
   static Future<bool> _checkInstallPermission() async {
     if (!Platform.isAndroid) return true;
-
+    
     try {
       // 检查是否有安装权限
       bool hasPermission = await Permission.requestInstallPackages.isGranted;
-
+      
       if (!hasPermission) {
         // 请求安装权限
         PermissionStatus status = await Permission.requestInstallPackages.request();
-
+        
         if (status.isGranted) {
           return true;
         } else if (status.isPermanentlyDenied) {
@@ -543,7 +543,7 @@ class DownloadManager {
           return false;
         }
       }
-
+      
       return true;
     } catch (e) {
       log('检查安装权限失败: $e');
@@ -555,7 +555,7 @@ class DownloadManager {
   static Future<void> _openFile(String filePath) async {
     try {
       log('尝试打开文件: $filePath');
-
+      
       // 如果是 APK 文件，先检查安装权限
       if (_isApkFile(filePath)) {
         bool hasPermission = await _checkInstallPermission();
@@ -563,12 +563,12 @@ class DownloadManager {
           return; // 没有权限，不继续打开
         }
       }
-
+      
       // 使用 open_filex 插件打开文件
       final result = await OpenFilex.open(filePath);
-
+      
       log('打开文件结果: ${result.type} - ${result.message}');
-
+      
       // 根据结果显示相应的提示
       switch (result.type) {
         case ResultType.done:
@@ -749,7 +749,7 @@ class DownloadController extends getx.GetxController {
 
   void updateProgress(double progress, int received, int total) {
     if (_isCancelled) return;
-
+    
     _progress = progress;
     _statusText = '${_formatBytes(received)} / ${_formatBytes(total)}';
     update();


### PR DESCRIPTION
## Summary / 摘要

- Support direct downloads for files generated as `blob:` URLs inside the OpenList WebView, including management backups.
- Capture each Blob in its originating loopback page and transfer it to Dart in 128 KiB chunks instead of passing the WebView-local URL to Dio, an external browser, or Android Intent.
- Reuse the existing download task UI, notifications, cancellation, and file-opening behavior while isolating temporary files and reserved target paths for concurrent downloads.
- Keep active Blob transfers alive by blocking reload, back navigation, and document-changing navigation until transfer cleanup completes.
- Normal HTTP/HTTPS download behavior is unchanged. No public API, configuration, storage format, migration, or related-repository change is required.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: None
- OpenList-Docs: None

## Related Issues / 关联 Issue

Fixes #59

## Testing / 测试

- [ ] `go test ./...` (not applicable to this Flutter-only change)
- [ ] Manual test / 手动测试: Not run; Android and iOS device verification is still required for backup download, cancellation, navigation blocking, and concurrent same-name downloads.
- [x] `flutter analyze lib/pages/web/web.dart lib/utils/download_manager.dart` (no new errors; four pre-existing diagnostics remain)
- [x] `git diff origin/main...HEAD --check`
- [x] Independent static review of the WebView/JavaScript transfer path, download lifecycle, cancellation, and concurrent file handling

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [ ] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

Formatting note: full-file Dart formatting was intentionally not retained because it produced unrelated whitespace churn; the final diff was checked with `git diff --check` and compared with `--ignore-all-space`.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。