### PR TITLE
fix(android): avoid foreground service crash on OEM frameworks

### DIFF
--- a/android/app/src/main/kotlin/com/openlist/mobile/OpenListService.kt
+++ b/android/app/src/main/kotlin/com/openlist/mobile/OpenListService.kt
@@ -400,11 +400,7 @@ class OpenListService : Service(), OpenList.Listener {
                 )
                 chan.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
                 chan.setShowBadge(false)
-                
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    chan.setBlockable(false)
-                }
-                
+
                 val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 notificationManager.createNotificationChannel(chan)
                 


### PR DESCRIPTION
## Summary / 摘要

- Remove the nonessential `NotificationChannel.setBlockable(false)` call from foreground-service notification channel initialization.
- Prevent `OpenListService.onCreate()` from crashing with `NoSuchMethodError` on HarmonyOS and other OEM-compatible frameworks that report API 29+ but omit this method.
- Preserve notification channel creation and the existing ongoing/no-clear foreground notification behavior.
- Issue #75 confirms the failing call through a stack trace. Issue #44 has the same Android 10/11 service-start symptoms and affected version range, so it is treated as the same root cause with high confidence, although that issue does not include a matching logcat.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #44
Fixes #75

## Testing / 测试

- [ ] `go test ./...`
- [ ] Manual test / 手动测试: HarmonyOS 2.0 / Android 10 OEM devices were not available in the local environment. / 本地环境没有可用的 HarmonyOS 2.0 / Android 10 OEM 真机。
- [x] Static review / 静态复查: verified the complete branch diff, ran `git diff --check`, confirmed no remaining `setBlockable` calls, and reviewed the foreground-service notification call chain. / 已检查完整分支差异、执行 `git diff --check`、确认仓库中不再存在 `setBlockable` 调用，并复查前台服务通知调用链。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。